### PR TITLE
[FEAT] : 회원가입 기능 구현 KAN-53

### DIFF
--- a/apps/main-web/package.json
+++ b/apps/main-web/package.json
@@ -10,18 +10,21 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
     "@repo/ui": "*",
+    "@use-funnel/browser": "^0.0.7",
     "next": "^14.2.6",
     "next-auth": "^4.24.8",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.2.3",
     "@repo/eslint-config": "*",
     "@repo/tailwind-config": "*",
     "@repo/typescript-config": "*",
-    "@repo/server-actions": "*",
     "@types/node": "^20.11.24",
     "@types/react": "^18.2.61",
     "@types/react-dom": "^18.2.19",

--- a/apps/main-web/src/app/(auth)/sign-up/page.tsx
+++ b/apps/main-web/src/app/(auth)/sign-up/page.tsx
@@ -1,21 +1,9 @@
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@repo/ui/components/ui/avatar";
-
-import { Button } from "@repo/ui/components/ui/button";
+import SignUpForm from "../../../components/layouts/signup/SignUpForm";
 
 export default function page() {
   return (
     <main>
-      <Button>버튼!!!!!</Button>
-      <p className="text-blue-500">하이</p>
-      sign-up page
-      <Avatar>
-        <AvatarImage src="https://github.com/shadcn.png" />
-        <AvatarFallback>CN</AvatarFallback>
-      </Avatar>
+      <SignUpForm />
     </main>
   );
 }

--- a/apps/main-web/src/components/layouts/signup/EmailVerification.tsx
+++ b/apps/main-web/src/components/layouts/signup/EmailVerification.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import {
+  EmailVerificationSchema,
+  EmailVerificationType,
+} from "../../../types/auth/signup";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@repo/ui/components/ui/form";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import React, { useState } from "react";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { Input } from "@repo/ui/components/ui/input";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+interface EmailVerificationProps {
+  onNext: (email: string, emailVerificationCode: string) => void;
+}
+
+export default function EmailVerification({ onNext }: EmailVerificationProps) {
+  const [isInputVisible, setIsInputVisible] = useState<boolean>(false);
+
+  const form = useForm<EmailVerificationType>({
+    resolver: zodResolver(EmailVerificationSchema),
+    defaultValues: {
+      email: "",
+      emailVerificationCode: "",
+    },
+  });
+
+  const isValidEmail = (email: string): boolean => {
+    // 이메일 중복 확인
+  };
+
+  const sendEmail = (eamil: string): string => {
+    //인증 코드 발송
+  };
+
+  const validateEmailAndSendVerificationCode = () => {
+    // if (isValidEmail()) {
+    //   setIsInputVisible(true);
+    //   sendEmail();
+    // }
+    setIsInputVisible(true);
+  };
+
+  const onSubmit: SubmitHandler<EmailVerificationType> = (values) => {
+    onNext(values.email, values.emailVerificationCode);
+  };
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormControl>
+                <Input placeholder="이메일" type="email" {...field} />
+              </FormControl>
+              <Button
+                type="button"
+                onClick={validateEmailAndSendVerificationCode}
+              >
+                인증
+              </Button>
+              {form.formState.errors.email && <FormMessage />}
+            </FormItem>
+          )}
+        ></FormField>
+        {isInputVisible && (
+          <FormField
+            control={form.control}
+            name="emailVerificationCode"
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Input placeholder="인증 코드" type="text" {...field} />
+                </FormControl>
+
+                {form.formState.errors.emailVerificationCode && <FormMessage />}
+              </FormItem>
+            )}
+          ></FormField>
+        )}
+        <Button>Next</Button>
+      </form>
+    </FormProvider>
+  );
+}

--- a/apps/main-web/src/components/layouts/signup/SignUpForm.tsx
+++ b/apps/main-web/src/components/layouts/signup/SignUpForm.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Step1, Step2, Step3 } from "../../../types/auth/signup";
+
+import EmailVerification from "./EmailVerification";
+import React from "react";
+import SignUpHeader from "./SignUpHeader";
+import TermsConsent from "./TermsConsent";
+import UserInfo from "./UserInfo";
+import { useFunnel } from "@use-funnel/browser";
+
+export default function SignUpForm() {
+  const funnel = useFunnel<{
+    step1: Step1;
+    step2: Step2;
+    step3: Step3;
+  }>({
+    id: "signup-funnel",
+    initial: {
+      step: "step1",
+      context: {},
+    },
+  });
+  return (
+    <section>
+      <SignUpHeader />
+      <funnel.Render
+        step1={({ history }) => (
+          <TermsConsent
+            onNext={({ terms }) => {
+              history.push("step2", {
+                terms,
+              });
+            }}
+          />
+        )}
+        step2={({ history, context }) => (
+          <EmailVerification
+            onNext={(email, emailVerificationCode) => {
+              history.push("step3", {
+                ...context,
+                email,
+                emailVerificationCode,
+              });
+            }}
+          />
+        )}
+        step3={({ context }) => (
+          <UserInfo
+            terms={context.terms}
+            email={context.email}
+            emailVerificationCode={context.emailVerificationCode}
+          />
+        )}
+      />
+    </section>
+  );
+}

--- a/apps/main-web/src/components/layouts/signup/SignUpHeader.tsx
+++ b/apps/main-web/src/components/layouts/signup/SignUpHeader.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function SignUpHeader() {
+  return <section></section>;
+}

--- a/apps/main-web/src/components/layouts/signup/TermsConsent.tsx
+++ b/apps/main-web/src/components/layouts/signup/TermsConsent.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@repo/ui/components/ui/form";
+import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
+import {
+  TermsConsentSchema,
+  TermsConsentType,
+} from "../../../types/auth/signup";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { Checkbox } from "@repo/ui/components/ui/checkbox";
+import React from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+interface TermsConsentProps {
+  onNext: (terms: TermsConsentType) => void;
+}
+
+const termList: Array<{
+  name: keyof TermsConsentType["terms"];
+  content: string;
+}> = [
+  { name: "term1", content: "약관 1에 동의합니다." },
+  { name: "term2", content: "약관 2에 동의합니다." },
+  { name: "term3", content: "약관 3에 동의합니다." },
+  { name: "term4", content: "약관 4에 동의합니다." },
+  { name: "term5", content: "약관 5에 동의합니다." },
+];
+
+export default function TermsConsent({ onNext }: TermsConsentProps) {
+  const form = useForm<TermsConsentType>({
+    resolver: zodResolver(TermsConsentSchema),
+    defaultValues: {
+      terms: {
+        term1: false,
+        term2: false,
+        term3: false,
+        term4: false,
+        term5: false,
+      },
+    },
+  });
+
+  const onSubmit: SubmitHandler<TermsConsentType> = (values) => {
+    onNext(values);
+  };
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        {termList.map((term, index) => (
+          <FormField
+            key={index}
+            control={form.control}
+            name={`terms.${term.name}`}
+            render={({ field }) => (
+              <FormItem>
+                <span>{term.content}</span>
+                <FormControl>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={(checked) => field.onChange(checked)}
+                  />
+                </FormControl>
+                {form.formState.errors.terms?.[term.name] && <FormMessage />}
+              </FormItem>
+            )}
+          ></FormField>
+        ))}
+        <Button type="submit">Next</Button>
+      </form>
+    </FormProvider>
+  );
+}

--- a/apps/main-web/src/components/layouts/signup/UserInfo.tsx
+++ b/apps/main-web/src/components/layouts/signup/UserInfo.tsx
@@ -1,0 +1,83 @@
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@repo/ui/components/ui/form";
+import { FormProvider, useForm } from "react-hook-form";
+import { UserInfoSchema, UserInfoType } from "../../../types/auth/signup";
+
+import { Button } from "@repo/ui/components/ui/button";
+import { Input } from "@repo/ui/components/ui/input";
+import React from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+interface UserInfoProps {
+  terms: {
+    term1: boolean;
+    term2: boolean;
+    term3: boolean;
+    term4: boolean;
+    term5: boolean;
+  };
+  email: string;
+  emailVerificationCode: string;
+}
+
+const formInputs: Array<{
+  name: keyof UserInfoType;
+  label: string;
+  type: string;
+}> = [
+  { name: "loginId", label: "아이디", type: "text" },
+  { name: "password", label: "비밀번호", type: "password" },
+  { name: "passwordConfirm", label: "비밀번호 확인", type: "password" },
+  { name: "nickname", label: "닉네임", type: "text" },
+];
+
+export default function UserInfo({
+  terms,
+  email,
+  emailVerificationCode,
+}: UserInfoProps) {
+  const form = useForm<UserInfoType>({
+    resolver: zodResolver(UserInfoSchema),
+    defaultValues: {
+      loginId: "",
+      password: "",
+      passwordConfirm: "",
+      nickname: "",
+    },
+  });
+
+  const onSubmit = (values: UserInfoType) => {
+    console.log(email, emailVerificationCode, values);
+  };
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        {formInputs.map((input, index) => (
+          <FormField
+            key={index}
+            control={form.control}
+            name={input.name}
+            render={({ field }) => (
+              <FormItem>
+                <FormControl>
+                  <Input
+                    placeholder={input.label}
+                    type={input.type}
+                    {...field}
+                  />
+                </FormControl>
+                {form.formState.errors?.[input.name] && <FormMessage />}
+              </FormItem>
+            )}
+          />
+        ))}
+        <Button>가입</Button>
+      </form>
+    </FormProvider>
+  );
+}

--- a/apps/main-web/src/types/auth/signup.ts
+++ b/apps/main-web/src/types/auth/signup.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+
+// 약관 동의 기본 스키마
+const mustAgree = z.boolean().refine((val) => val === true, {
+  message: "약관에 동의해야 합니다.",
+});
+
+// Step1 약관 동의 스키마
+export const TermsConsentSchema = z.object({
+  terms: z.object({
+    term1: mustAgree,
+    term2: mustAgree,
+    term3: mustAgree,
+    term4: mustAgree,
+    term5: mustAgree,
+  }),
+});
+
+// Step2 이메일 인증 스키마
+export const EmailVerificationSchema = z.object({
+  email: z
+    .string()
+    .email("유효한 이메일을 입력해야 합니다.")
+    .refine((val) => val.trim().length > 0, {
+      message: "이메일을 입력해야 합니다.",
+    }),
+  emailVerificationCode: z.string().refine((val) => val.trim().length > 0, {
+    message: "인증 코드를 입력해야 합니다.",
+  }),
+});
+
+// Step3 계정 정보 스키마
+export const UserInfoSchema = z
+  .object({
+    loginId: z
+      .string()
+      .min(4, "아이디는 최소 4자 이상이어야 합니다.")
+      .max(20, "아이디는 최대 20자 이하이어야 합니다.")
+      .regex(
+        /^[a-zA-Z0-9_]+$/,
+        "아이디는 알파벳, 숫자, 언더스코어만 포함해야 합니다.",
+      ),
+    password: z
+      .string()
+      .min(8, "비밀번호는 최소 8자 이상이어야 합니다.")
+      .max(20, "비밀번호는 최대 20자 이하이어야 합니다.")
+      .regex(/^(?!.*(.)\1{2})/, "같은 문자가 3개 이상 연속될 수 없습니다."),
+    passwordConfirm: z.string(),
+    nickname: z
+      .string()
+      .min(2, { message: "닉네임을 입력해주세요" })
+      .max(10, { message: "닉네임은 최대 10자 입니다" }),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.passwordConfirm) {
+      ctx.addIssue({
+        path: ["passwordConfirm"],
+        message: "비밀번호가 일치하지 않습니다.",
+        code: z.ZodIssueCode.custom,
+      });
+    }
+  });
+
+export type TermsConsentType = z.infer<typeof TermsConsentSchema>;
+export type EmailVerificationType = z.infer<typeof EmailVerificationSchema>;
+export type UserInfoType = z.infer<typeof UserInfoSchema>;
+
+export interface Step1 {
+  terms?: {
+    term1: boolean;
+    term2: boolean;
+    term3: boolean;
+    term4: boolean;
+    term5: boolean;
+  };
+  email?: string;
+  emailVerification?: string;
+  loginId?: string;
+  password?: string;
+  passwordConfirm?: string;
+  nickname?: string;
+}
+
+export interface Step2 {
+  terms: {
+    term1: boolean;
+    term2: boolean;
+    term3: boolean;
+    term4: boolean;
+    term5: boolean;
+  };
+  email?: string;
+  emailVerificationCode?: string;
+  loginId?: string;
+  password?: string;
+  passwordConfirm?: string;
+  nickname?: string;
+}
+
+export interface Step3 {
+  terms: {
+    term1: boolean;
+    term2: boolean;
+    term3: boolean;
+    term4: boolean;
+    term5: boolean;
+  };
+  email: string;
+  emailVerificationCode: string;
+  loginId?: string;
+  password?: string;
+  passwordConfirm?: string;
+  nickname?: string;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,11 +91,15 @@
     "apps/main-web": {
       "version": "1.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.1",
         "@repo/ui": "*",
+        "@use-funnel/browser": "^0.0.7",
         "next": "^14.2.6",
         "next-auth": "^4.24.8",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-hook-form": "^7.53.1",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^14.2.3",
@@ -655,6 +659,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.9.1.tgz",
+      "integrity": "sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.0.tgz",
@@ -1164,6 +1177,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.1.2.tgz",
+      "integrity": "sha512-/i0fl686zaJbDQLNKrkCbMyDm6FQMt4jg323k7HuqitoANm9sE23Ql8yOK3Wusk34HSLKDChhMux05FnP6KUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-presence": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.0.tgz",
@@ -1269,6 +1312,29 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.0.tgz",
+      "integrity": "sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@radix-ui/react-portal": {
@@ -1460,6 +1526,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.0.tgz",
+      "integrity": "sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
+      "integrity": "sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
@@ -1527,15 +1626,6 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
-      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@types/estree": {
@@ -1868,6 +1958,27 @@
       "dev": true,
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/@use-funnel/browser": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@use-funnel/browser/-/browser-0.0.7.tgz",
+      "integrity": "sha512-f9MAUIglaO9b+0kMyZVaiKwPiNJLruc5GDRt2vfs6ExPb678dfpQSyPKbU8nik71hgO7GSjVwORbyx2AthWHzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-funnel/core": "^0.0.7"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/@use-funnel/core": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@use-funnel/core/-/core-0.0.7.tgz",
+      "integrity": "sha512-aInoq3dv5MSuYIPb1w1Y1pTJEAncQghoX99suMwsqnkMGunnCOw6UAPo131oyM4H52m2rbsoBnHBreDEDYmvzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
     },
     "node_modules/@vercel/style-guide": {
       "version": "5.2.0",
@@ -7306,6 +7417,22 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.53.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
+      "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -9136,6 +9263,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/config-eslint": {
       "name": "@repo/eslint-config",
       "version": "0.0.0",
@@ -9162,8 +9298,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-avatar": "^1.1.1",
+        "@radix-ui/react-checkbox": "^1.1.2",
         "@radix-ui/react-icons": "^1.3.0",
+        "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.2",
         "class-variance-authority": "^0.7.0",
@@ -9171,8 +9310,10 @@
         "date-fns": "^3.6.0",
         "lucide-react": "^0.453.0",
         "react-day-picker": "^8.10.1",
+        "react-hook-form": "^7.53.1",
         "tailwind-merge": "^2.5.4",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@repo/eslint-config": "*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,8 +38,11 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-avatar": "^1.1.1",
+    "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.2",
     "class-variance-authority": "^0.7.0",
@@ -47,7 +50,9 @@
     "date-fns": "^3.6.0",
     "lucide-react": "^0.453.0",
     "react-day-picker": "^8.10.1",
+    "react-hook-form": "^7.53.1",
     "tailwind-merge": "^2.5.4",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
   }
 }

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+const Checkbox = React.forwardRef<
+  React.ElementRef<typeof CheckboxPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <CheckboxPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer h-4 w-4 shrink-0 rounded-sm border border-slate-200 border-slate-900 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=checked]:text-slate-50 dark:border-slate-800 dark:border-slate-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300 dark:data-[state=checked]:bg-slate-50 dark:data-[state=checked]:text-slate-900",
+      className,
+    )}
+    {...props}
+  >
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
+      <Check className="h-4 w-4" />
+    </CheckboxPrimitive.Indicator>
+  </CheckboxPrimitive.Root>
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+
+export { Checkbox };

--- a/packages/ui/src/components/ui/form.tsx
+++ b/packages/ui/src/components/ui/form.tsx
@@ -1,0 +1,180 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
+
+import { cn } from "@repo/ui/lib/utils";
+import { Label } from "@repo/ui/components/ui/label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+);
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  );
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-red-500 dark:text-red-900", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn(
+        "text-sm font-medium text-red-500 dark:text-red-900",
+        className,
+      )}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import { cn } from "@repo/ui/lib/utils";
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-slate-950 placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:file:text-slate-50 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/packages/ui/src/components/ui/label.tsx
+++ b/packages/ui/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@repo/ui/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };


### PR DESCRIPTION
## 📌 관련 이슈

- closed: KAN-53

## ✨ PR 세부 내용

회원가입 useFunnel을 사용해서 multi-step-form 형태로 세팅
이메일 중복 확인, 이메일 인증, 회원가입 API가 나오면 바로 연동 가능

## ⌛ 소요 시간
3일