### PR TITLE
KAN-417 마이 페이지 펫 프로필 수정 기능 업데이트

### DIFF
--- a/apps/main-web/src/actions/user/index.ts
+++ b/apps/main-web/src/actions/user/index.ts
@@ -2,21 +2,19 @@
 
 import { PetInfo, PetProfileType, UserInfo } from '../../types/user';
 
-import { revalidatePath } from 'next/cache';
 import { CommonResponse } from '../../types/responseType';
 import { fetchDataforMembers } from '../common/common';
+import { revalidatePath } from 'next/cache';
 
 const BASE_URL = `${process.env.BACKEND_URL}/user-service`;
 
 export const getUserProfile = async (uuid: string): Promise<UserInfo> => {
-  console.log('검색중인 uuid', uuid);
   const API_URL = `${BASE_URL}/read/userprofile?userUuid=${uuid}`;
   const response = await fetch(API_URL, {
     method: 'GET',
   });
 
   const result = (await response.json()) as CommonResponse<UserInfo>;
-  console.log('유저프로필쪽', result);
   return result.result;
 };
 

--- a/apps/main-web/src/components/pages/mypage/AddPet.tsx
+++ b/apps/main-web/src/components/pages/mypage/AddPet.tsx
@@ -9,8 +9,6 @@ import {
 
 import AddPetForm from './AddPetForm';
 import { CirclePlus } from 'lucide-react';
-import InputPetForm from './InputPetForm';
-import { registerPetProfile } from '../../../actions/user';
 import { useState } from 'react';
 
 export default function AddPet() {
@@ -34,7 +32,6 @@ export default function AddPet() {
       >
         <DialogTitle className="hidden" />
         <AddPetForm setOpen={setOpen} />
-        {/* <InputPetForm action={registerPetProfile} setOpen={setOpen} /> */}
       </DialogContent>
     </Dialog>
   );

--- a/apps/main-web/src/components/pages/mypage/EditPetForm.tsx
+++ b/apps/main-web/src/components/pages/mypage/EditPetForm.tsx
@@ -18,8 +18,8 @@ import { extractCommonUrl, getMediaUrl } from '../../../utils/media';
 import { Button } from '@repo/ui/components/ui/button';
 import { Form } from '@repo/ui/components/ui/form';
 import ImageUpload from '../../forms/ImageUpload';
+import { updatePetProfile } from '../../../actions/user';
 import { useForm } from 'react-hook-form';
-import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 interface EditPetFormProps {
@@ -60,11 +60,10 @@ export default function EditPetForm({
       weight: values.weight,
       image: image,
     };
-    console.log(body);
-    // const response = await updatePetProfile(body);
-    // if (response.isSuccess) {
-    //   setOpen(false);
-    // }
+    const response = await updatePetProfile(body);
+    if (response.isSuccess) {
+      setOpen(false);
+    }
   };
 
   return (

--- a/apps/main-web/src/components/pages/profile/PetList.tsx
+++ b/apps/main-web/src/components/pages/profile/PetList.tsx
@@ -16,7 +16,6 @@ import {
   AlertDialogTrigger,
 } from '@repo/ui/components/ui/alert-dialog';
 import { Grid, Pagination } from 'swiper/modules';
-import React, { useState } from 'react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import EditPetForm from '../mypage/EditPetForm';
@@ -24,6 +23,7 @@ import InputFormDialog from '../../forms/InputFormDialog';
 import { PencilLine } from 'lucide-react';
 import { PetInfo } from '../../../types/user';
 import ProfileAvatar from '../../ui/ProfileAvatar';
+import React from 'react';
 import { deletePet } from '../../../actions/user';
 import { getMediaUrl } from '../../../utils/media';
 
@@ -33,15 +33,8 @@ interface PetListProps {
 }
 
 function PetList({ petList, isEdit }: PetListProps) {
-  const [open, setOpen] = useState(false);
   const onDeletePet = async (petUuid: string) => {
     await deletePet(petUuid);
-  };
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    console.log('Form submitted:', Object.fromEntries(formData));
-    setOpen(false);
   };
 
   return (
@@ -57,22 +50,21 @@ function PetList({ petList, isEdit }: PetListProps) {
         {petList.map((pet, idx) => {
           const image = getMediaUrl(pet.image);
           const defaultValues = pet;
-          // console.log(pet.name, pet.gender);
           return (
             <SwiperSlide key={idx}>
               <ProfileAvatar
-                imgUrl={getMediaUrl(pet.image)}
+                imgUrl={image}
                 className="h-[77px] min-h-[77px] w-[77px] min-w-[77px]"
                 imgAlt={pet.name}
               />
 
-              <div className="relative flex max-w-[297px] flex-col gap-1">
+              <div className="relative flex max-w-[297px] flex-col gap-1 pl-4">
                 <p className="font-semibold">
                   {pet.name} {pet.age}
                 </p>
                 <div className="flex gap-1">
                   <p className="text-grey text-sm">{pet.type} /</p>
-                  <p className="text-grey text-sm">남자 /</p>
+                  <p className="text-grey text-sm">{pet.gender} /</p>
                   <p className="text-grey text-sm">{pet.weight}kg</p>
                 </div>
                 <div>
@@ -94,7 +86,7 @@ function PetList({ petList, isEdit }: PetListProps) {
                     <AlertDialogTrigger className="bg-lookids hover:bg-lookids/90 h-7 rounded-sm">
                       <p className="text-white text-sm">삭제</p>
                     </AlertDialogTrigger>
-                    <AlertDialogContent>
+                    <AlertDialogContent className="w-3/4">
                       <AlertDialogHeader>
                         <AlertDialogTitle>
                           <AlertDialogDescription>
@@ -109,7 +101,7 @@ function PetList({ petList, isEdit }: PetListProps) {
                         >
                           삭제
                         </AlertDialogAction>
-                        <AlertDialogCancel className="h-8">
+                        <AlertDialogCancel className="h-8 m-0">
                           취소
                         </AlertDialogCancel>
                       </AlertDialogFooter>

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import * as React from 'react';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import * as React from 'react';
 
-import { cn } from '@repo/ui/lib/utils';
 import { buttonVariants } from '@repo/ui/components/ui/button';
+import { cn } from '@repo/ui/lib/utils';
 
 const AlertDialog = AlertDialogPrimitive.Root;
 
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-sm translate-x-[-50%] rounded-lg translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
@@ -51,7 +51,8 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col space-y-2 text-center sm:text-left',
+      // 'flex flex-col space-y-2 text-center sm:text-left',
+      'flex flex-col space-y-2 text-left',
       className
     )}
     {...props}
@@ -65,7 +66,8 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      // 'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      'flex justify-end space-x-2',
       className
     )}
     {...props}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -41,7 +41,7 @@
   margin: 0 !important;
   height: 120px !important;
   display: flex;
-  gap: 16;
+  /* gap: 16; */
 }
 
 .petList .swiper-pagination-bullet {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#KANNumber)
-->

## 📌 관련 이슈

- closed: KAN-417

## ✨ PR 세부 내용
1. 펫 프로필 사진이랑 프로필 사이에 gap이 배포시에 invalid property value이라고 작동하지 않아서 패딩으로 조절했습니다.
2. 펫 삭제 AlertDialog의 width를 조절하고 AlertDialogFooter와 AlertDialogHeader의 ui를 수정했습니다.

## ⌛ 소요 시간
