### PR TITLE
[FEAT] : 피드 상세페이지에서 좋아요 기능과 공유기능 구현 KAN-438

### DIFF
--- a/apps/main-web/src/actions/favorite/favorite.ts
+++ b/apps/main-web/src/actions/favorite/favorite.ts
@@ -1,3 +1,4 @@
+'use server';
 import { revalidateTag } from 'next/cache';
 import { CommonResponse, responseList } from '../../types/responseType';
 import { fetchDataforMembers } from '../common/common';

--- a/apps/main-web/src/components/common/feedcard/ShareModal.tsx
+++ b/apps/main-web/src/components/common/feedcard/ShareModal.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@repo/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@repo/ui/components/ui/dialog';
+import { Copy } from 'lucide-react';
+import { useState } from 'react';
+
+interface ShareModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  url: string;
+}
+
+export function ShareModal({ isOpen, onClose, url }: ShareModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-lookids">공유하기</DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4">
+          <Button
+            onClick={copyToClipboard}
+            variant="outline"
+            className="flex items-center gap-2"
+          >
+            <Copy className="h-4 w-4 text-lookids" />
+            {copied ? '링크 복사됨!' : '링크 복사'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/main-web/src/components/common/feedcard/SocialCard.tsx
+++ b/apps/main-web/src/components/common/feedcard/SocialCard.tsx
@@ -6,17 +6,23 @@ import {
 } from '@repo/ui/components/ui/avatar';
 import { Card, CardContent, CardFooter } from '@repo/ui/components/ui/card';
 
+import { motion } from 'framer-motion';
 import { Share2, ThumbsUp } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import {
+  getIsFavorite,
+  putFavoriteComment,
+} from '../../../actions/favorite/favorite';
 import { getFeedDetail } from '../../../actions/feed/FeedCard';
 import { FeedDetail } from '../../../types/feed/FeedType';
 import { formatDate } from '../../../utils/formatDate';
 import { getMediaUrl } from '../../../utils/media';
-import LikeButton from '../LikeButton';
+import { ShareModal } from './ShareModal';
 
 export default function SocialCard({
   isDetail,
@@ -25,6 +31,10 @@ export default function SocialCard({
   isDetail: boolean;
   feedCode: string;
 }) {
+  const router = useRouter();
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+
+  const [likeCount, setLikeCount] = useState(0);
   const [isLiked, setIsLiked] = useState(false);
   const [feedDetail, setFeedDetail] = useState<FeedDetail>({
     uuid: '',
@@ -35,10 +45,32 @@ export default function SocialCard({
     tagList: [],
     mediaUrlList: [],
     createdAt: '',
+    feedCode: '',
   });
+  useEffect(() => {
+    // 좋아요 여부 조회
+    getIsFavorite(feedCode).then((res) => {
+      setIsLiked(res);
+    });
+  }, [feedCode]);
 
-  const toggleLike = () => {
+  const handleShareClick = () => {
+    setIsShareModalOpen(true);
+  };
+  const toggleLike = async (feedDetail: FeedDetail) => {
     setIsLiked(!isLiked);
+    setLikeCount(isLiked ? likeCount - 1 : likeCount + 1);
+    try {
+      const res = await putFavoriteComment(
+        feedDetail.uuid,
+        feedDetail.feedCode,
+        '피드'
+      );
+    } catch (error) {
+      setIsLiked(!isLiked);
+      setLikeCount(isLiked ? likeCount + 1 : likeCount - 1);
+      throw new Error(`좋아요 등록 중 실패: ${error}`);
+    }
     // 추가 로직 (API 호출 등)도 이곳에 구현 가능
   };
 
@@ -55,90 +87,129 @@ export default function SocialCard({
   }, [feedCode]);
 
   return (
-    <Card className={`h-2/5 overflow-hidden p-4 ${isDetail ? 'border-0' : ''}`}>
-      {/* Social Card Image */}
-      {!isDetail && (
-        <div className="relative">
-          <Link href={`/feed/${feedCode}`}>
-            <Image
-              src={`${getMediaUrl(feedDetail.mediaUrlList?.[0] || '')}`}
-              width={500}
-              height={300}
-              alt="Feed image"
-              className="w-full rounded-lg object-cover"
-            />
-          </Link>
-
-          <LikeButton isLiked={isLiked} onToggle={toggleLike} />
-        </div>
-      )}
-
-      {isDetail && (
-        <Swiper
-          modules={[Pagination]}
-          pagination={{ clickable: true }}
-          className="rounded-lg overflow-hidden"
-        >
-          {feedDetail.mediaUrlList.map((url, index) => (
-            <SwiperSlide key={index}>
+    <>
+      <Card
+        className={`h-2/5 overflow-hidden p-4 ${isDetail ? 'border-0' : ''}`}
+      >
+        {/* Social Card Image */}
+        {!isDetail && (
+          <div className="relative">
+            <Link href={`/feed/${feedCode}`}>
               <Image
-                src={getMediaUrl(url)}
-                alt={`Feed image ${index + 1}`}
+                src={`${getMediaUrl(feedDetail.mediaUrlList?.[0] || '')}`}
                 width={500}
                 height={300}
-                className="w-full object-cover"
+                alt="Feed image"
+                className="w-full rounded-lg object-cover"
               />
-            </SwiperSlide>
-          ))}
-        </Swiper>
-      )}
-
-      <CardContent className="mt-4 px-2">
-        <div className="flex items-start justify-between">
-          <div className="mb-4 flex items-center space-x-4">
-            <Avatar>
-              <AvatarImage
-                src={getMediaUrl(feedDetail.image)}
-                alt={feedDetail.nickname}
-                className="object-cover"
-              />
-              <AvatarFallback>RF</AvatarFallback>
-            </Avatar>
-            <div className="flex-1">
-              <h3 className="text-md font-extrabold text-black">
-                {feedDetail.nickname}
-              </h3>
-              <p className="text-xs text-black">{`@${feedDetail.tag}`}</p>
-            </div>
+            </Link>
           </div>
-          <p className="text-xs text-gray-500">
-            {formatDate(feedDetail.createdAt)}
-          </p>
-        </div>
-        <p
-          className={`w-full text-sm text-gray-400 line-clamp-2 text-ellipsis whitespace-pre-wrap ${
-            isDetail ? '' : 'line-clamp-2'
-          }`}
-        >
-          {feedDetail.content}
-        </p>
-      </CardContent>
+        )}
 
-      {/* SocialCard Reaction Section */}
-      <CardFooter className="flex gap-x-5 border-t border-gray-100 px-2 py-3 text-xs text-gray-400">
-        <ul className="flex items-center gap-x-2">
-          <li>
-            <ThumbsUp className="text-lookids h-4 w-4" />
-          </li>
-          <li>{`${178} Likes`}</li>
-        </ul>
-        <ul className="flex items-center gap-x-2">
-          <li>
-            <Share2 className="text-lookids h-4 w-4" />
-          </li>
-          <li>{`${12} Shares`}</li>
-        </ul>
-      </CardFooter>
-    </Card>
+        {isDetail && (
+          <Swiper
+            modules={[Pagination]}
+            pagination={{ clickable: true }}
+            className="rounded-lg overflow-hidden"
+          >
+            {feedDetail.mediaUrlList.map((url, index) => (
+              <SwiperSlide key={index}>
+                <Image
+                  src={getMediaUrl(url)}
+                  alt={`Feed image ${index + 1}`}
+                  width={500}
+                  height={300}
+                  className="w-full object-cover"
+                />
+              </SwiperSlide>
+            ))}
+          </Swiper>
+        )}
+
+        <CardContent className="mt-4 px-2">
+          <div className="flex items-start justify-between ">
+            <div
+              className="mb-4 flex items-center space-x-4 hover:cursor-pointer"
+              onClick={() =>
+                router.push(`/user/${feedDetail.nickname}-${feedDetail.tag}`)
+              }
+            >
+              <Avatar>
+                <AvatarImage
+                  src={getMediaUrl(feedDetail.image)}
+                  alt={feedDetail.nickname}
+                  className="object-cover"
+                />
+                <AvatarFallback>RF</AvatarFallback>
+              </Avatar>
+              <div className="flex-1">
+                <h3 className="text-md font-extrabold text-black">
+                  {feedDetail.nickname}
+                </h3>
+                <p className="text-xs text-black">{`@${feedDetail.tag}`}</p>
+              </div>
+            </div>
+            <p className="text-xs text-gray-500">
+              {formatDate(feedDetail.createdAt)}
+            </p>
+          </div>
+          <p
+            className={`w-full text-sm text-gray-400 line-clamp-2 text-ellipsis whitespace-pre-wrap ${
+              isDetail ? '' : 'line-clamp-2'
+            }`}
+          >
+            {feedDetail.content}
+          </p>
+        </CardContent>
+
+        {/* SocialCard Reaction Section */}
+        <CardFooter className="flex gap-x-5 border-t border-gray-100 px-2 py-3 text-xs text-gray-400">
+          <ul className="flex items-center gap-x-2">
+            <li>
+              <motion.div whileTap={{ scale: 0.9 }} whileHover={{ scale: 1.1 }}>
+                <motion.div
+                  animate={{
+                    scale: isLiked ? [1, 1.2, 1] : 1,
+                    color: isLiked ? '#fd9340' : '#94A3B8',
+                  }}
+                  transition={{ duration: 0.3 }}
+                >
+                  <ThumbsUp
+                    className={`h-4 w-4 cursor-pointer`}
+                    onClick={() => toggleLike(feedDetail)}
+                  />
+                </motion.div>
+              </motion.div>
+            </li>
+            <li>
+              <motion.span
+                key={likeCount}
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                {`${likeCount} Likes`}
+              </motion.span>
+            </li>
+          </ul>
+          <ul className="flex items-center gap-x-2">
+            <li>
+              <Share2
+                className="text-lookids h-4 w-4 cursor-pointer"
+                onClick={handleShareClick}
+              />
+            </li>
+            <li className="cursor-pointer" onClick={handleShareClick}>
+              공유하기
+            </li>
+          </ul>
+        </CardFooter>
+      </Card>
+      <ShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        url={`https://lookids.online/feed/${feedCode}`}
+      />
+    </>
   );
 }

--- a/apps/main-web/src/components/common/feedcard/SocialCardwithData.tsx
+++ b/apps/main-web/src/components/common/feedcard/SocialCardwithData.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardFooter } from '@repo/ui/components/ui/card';
 import { Heart, Share2, ThumbsUp } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -33,6 +34,7 @@ export default function SocialCardwithData({
       setIsLiked(res);
     });
   }, [feedData.feedCode]);
+  const router = useRouter();
   const [isLiked, setIsLiked] = useState(false);
   const handleLike = async (feedData: FeedDetail) => {
     setIsLiked(!isLiked);
@@ -101,7 +103,12 @@ export default function SocialCardwithData({
 
       <CardContent className="mt-4 px-2">
         <div className="flex items-start justify-between">
-          <div className="mb-4 flex items-center space-x-4">
+          <div
+            className="mb-4 flex items-center space-x-4 hover:cursor-pointer"
+            onClick={() =>
+              router.push(`/user/${feedData.nickname}-${feedData.tag}`)
+            }
+          >
             <Avatar>
               <AvatarImage
                 src={getMediaUrl(feedData.image)}


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#KANNumber)
-->

## 📌 관련 이슈

- closed:  KAN-438

## ✨ PR 세부 내용

[FEAT] : 피드 상세페이지에서 좋아요 기능과 공유기능 구현 KAN-438
- 피드 상세페이지에서 좋아요 UI 추가 및 API 연동
- 피드 공유하기 눌렀을 때 , Modal 열어서 링크복사 눌렀을때 URL 복사
- 피드 카드에서 Avartar쪽 클릭시 유저 프로필페이지로 이동하게 설정

## ⌛ 소요 시간
1H