### PR TITLE
KAN-537 회원가입 / 유저 프로필 페이지 버그 수정

### DIFF
--- a/apps/main-web/src/components/forms/EmailVerificationForm.tsx
+++ b/apps/main-web/src/components/forms/EmailVerificationForm.tsx
@@ -133,6 +133,12 @@ export default function EmailVerificationForm({
                     placeholder="이메일"
                     type="email"
                     {...field}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        validateEmailAndSendVerificationCodeToEmail();
+                      }
+                    }}
                   />
                 </FormControl>
                 <div className="flex justify-center">

--- a/apps/main-web/src/components/pages/profile/FollowButton.tsx
+++ b/apps/main-web/src/components/pages/profile/FollowButton.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import {
-  putFollowToggle,
-  putFollowToggle2,
-} from '../../../actions/follow/Follow';
-
 import { Button } from '@repo/ui/components/ui/button';
 import { cn } from '@repo/ui/lib/utils';
+import { putFollowToggle } from '../../../actions/follow/Follow';
+import { useDebouncedCallback } from 'use-debounce';
 
 interface FollowButtonProps {
   token: string;
@@ -20,15 +17,17 @@ function FollowButton({
   targetUuid,
   followState,
 }: FollowButtonProps) {
-  const handleFollow = async () => {
+  const handleFollow = useDebouncedCallback(async () => {
     const response = await putFollowToggle(token, uuid, targetUuid);
-  };
+  }, 300);
 
   const className = followState
     ? 'bg-lookids hover:bg-lookids/90 text-white'
     : 'border border-lookids bg-white hover:bg-lookids hover:text-white text-lookids';
+
   return (
     <Button
+      key={followState ? 'followed' : 'not-followed'}
       onClick={handleFollow}
       className={cn('w-3/5 rounded-[12px] py-5 flex items-center', className)}
     >


### PR DESCRIPTION
<!--
PR 이름 컨벤션
feat: ~~(#KANNumber)
-->

## 📌 관련 이슈

- closed: #KAN-537

## ✨ PR 세부 내용

1. 이메일 인증할 때 이메일을 입력하고 엔터를 누르면 뒤로가기가 되는 버그가 있는데 수정했습니다.

2. 유저 프로필 페이지에서 팔로우 버튼을 토글할 때 버튼의 배경색이 pc에서는 잘 바뀌는데 모바일에서는 바뀌질 않습니다. 이를 수정했습니다.

## ⌛ 소요 시간
